### PR TITLE
Issue#28 - change RELEASE_PATH for distillery 1.0.0

### DIFF
--- a/edib/shared.mk
+++ b/edib/shared.mk
@@ -10,7 +10,7 @@ APP_VER        = $(shell $(APPINFO_RUNNER) version)
 
 MIX_ENV       ?= prod
 RELEASE        = releases/$(APP_VER)/$(APP_NAME).tar.gz
-RELEASE_PATH   = $(APP_DIR)/rel/$(APP_NAME)
+RELEASE_PATH   = $(APP_DIR)/_build/$(MIX_ENV)/rel/$(APP_NAME)
 RELEASE_FILE   = $(RELEASE_PATH)/$(RELEASE)
 
 STAGE_DIR      = /stage

--- a/tools/libdeps.exs
+++ b/tools/libdeps.exs
@@ -1,6 +1,6 @@
 #!/usr/bin/env elixir
 defmodule Libdeps do
-  @relpath "app/rel"
+  @relpath "app/_build"
   @lddpath_regex ~r/\/(lib|usr\/lib)[^ ]+/
 
   def all_files do

--- a/tools/libdeps.exs
+++ b/tools/libdeps.exs
@@ -1,6 +1,7 @@
 #!/usr/bin/env elixir
 defmodule Libdeps do
-  @relpath "app/_build"
+  @current_mix_env System.get_env("MIX_ENV") || "prod"
+  @relpath "app/_build/#{@current_mix_env}/rel"
   @lddpath_regex ~r/\/(lib|usr\/lib)[^ ]+/
 
   def all_files do


### PR DESCRIPTION
The PR is for `edib` v0.9.0, it changes the `RELEASE_PATH` to `$(APP_DIR)/_build/$(MIX_ENV)/rel/$(APP_NAME)` to meet the  [CHANGELOG.md](https://github.com/bitwalker/distillery/blob/master/CHANGELOG.md#100) of `distillery` 1.0.0

```
Default output path for release artifacts is _build/<env>/rel/<relname>, 
this can be configured in rel/config.exs with set output_dir: "path"
```

Btw, I was tring to change `tools/libdeps.exs` to something like:

```elixir
@relpath "app/_build/prod/rel" # This is working when `MIX_ENV=prod mix edib`
```

but I cannot pass `MIX_ENV` to that file:

```elixir
@relpath "app/_build/#{Mix.env}/rel" # This is not working when `MIX_ENV=prod mix edib`
```

which means the `relpath` is different from the original one.

*******

There's another option for this change. In `rel/config.exs`  set `output_dir`:
```elixir
set output_dir: "app/rel"
```

issue: https://github.com/edib-tool/mix-edib/issues/28