### PR TITLE
Issue#28 - Changed release path to use distillery 1.0+

### DIFF
--- a/edib/shared.mk
+++ b/edib/shared.mk
@@ -10,7 +10,7 @@ APP_VER        = $(shell $(APPINFO_RUNNER) version)
 
 MIX_ENV       ?= prod
 RELEASE        = releases/$(APP_VER)/$(APP_NAME).tar.gz
-RELEASE_PATH   = $(APP_DIR)/rel/$(APP_NAME)
+RELEASE_PATH   = $(APP_DIR)/_build/$(MIX_ENV)/rel/$(APP_NAME)
 RELEASE_FILE   = $(RELEASE_PATH)/$(RELEASE)
 
 STAGE_DIR      = /stage


### PR DESCRIPTION
## Breaking Change
Needs distillery 1.0+ to work

@luckynum7 made these changes in https://github.com/edib-tool/mix-edib/issues/28

Release Notes that depict these changes
https://github.com/bitwalker/distillery/blob/master/CHANGELOG.md#100