### PR TITLE
WIP:Phoenix 1.3 and npm deploy

### DIFF
--- a/tools/app_info
+++ b/tools/app_info
@@ -13,7 +13,7 @@ get_info() {
 }
 
 case $1 in
-  name|version|distillery|phoenix)
+  name|version|distillery|phoenix|phoenix_1_3)
     get_info $1
     ;;
   debug)

--- a/tools/app_info.exs
+++ b/tools/app_info.exs
@@ -3,11 +3,12 @@ defmodule AppInfo do
   def version, do: config() |> Keyword.get(:version)
   def distillery, do: deps() |> Keyword.has_key?(:distillery)
   def phoenix, do: deps() |> Keyword.has_key?(:phoenix)
-  def phoenix_1_3 do
+  def phoenix_1_3() do
    deps()
    |> Keyword.get(:phoenix)
-   |> elem(1)
-   |> Version.match?(">= 1.3-a")
+   |> String.split()
+   |> Enum.at(1)
+   |> Version.match?(">= 1.3.0-a")
  end
 
   defp config, do: Mix.Project.config()

--- a/tools/app_info.exs
+++ b/tools/app_info.exs
@@ -3,6 +3,14 @@ defmodule AppInfo do
   def version, do: config() |> Keyword.get(:version)
   def distillery, do: deps() |> Keyword.has_key?(:distillery)
   def phoenix, do: deps() |> Keyword.has_key?(:phoenix)
+  def phoenix_1_3 do
+   deps()
+   |> Keyword.get(:phoenix)
+   |> elem(1)
+   |> Version.match?(">= 1.3-a")
+ end
+
   defp config, do: Mix.Project.config()
   defp deps, do: config() |> Keyword.get(:deps)
+
 end


### PR DESCRIPTION
Two things in this PR, both linked to phoenix assets.

1. We now use `npm run deploy` instead of calling to Brunch. It makes it easier for users to switch tooling, and it allows for other fix (i had a SASS problem with alpine...).

2. We now test on phoenix 1.3 or not and move to `assets` if yes. It is not really that nice, because phoenix 1.3 do not force to move the assets. A better solution would be to ask users to give us the path to their assets directory, if they have one... but it means more user involvement... We could also just check if `assets` exist at the root and move there if needed...

I am still open to ideas for 2. The assets pipeline is always a pain.